### PR TITLE
Allowed specification of Regeion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # Overview
 I wanted to be able to use a simple AWS credentials provider to assume into a role using the credentials in my default profile when using the AWS Athena JDBC driver.
 
+## Building
+
+To build the credential provider as a fat jar:
+```bash
+mvn clean assembly:assembly -DdescriptorId=jar-with-dependencies
+```
+
+## IntelliJ
+
+In IntelliJ, under the Athena driver configuration, add the jar generated from the previous steps under "Driver Files".
+
+You should have two jars under "Driver Files":
+
+ - `AthenaJDBCx.x.x.x.jar`
+ - `sts-credentials-provider-0.0.1-SNAPSHOT-jar-with-dependencies`
+
+## Config
+
 My driver config includes the following jars:
 
 ```

--- a/src/main/java/com/hawknewton/maven_test/STSAssumeRoleFromProfileCredentialsProvider.java
+++ b/src/main/java/com/hawknewton/maven_test/STSAssumeRoleFromProfileCredentialsProvider.java
@@ -9,11 +9,17 @@ import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
 
 public class STSAssumeRoleFromProfileCredentialsProvider implements AWSCredentialsProvider {
 	private AWSCredentialsProvider provider;
-	
+
 	public STSAssumeRoleFromProfileCredentialsProvider(String roleArn) {
+		this(roleArn, "us-east-1");
+	}
+
+	public STSAssumeRoleFromProfileCredentialsProvider(String roleArn, String region) {
 		String sessionName =  "STSAssumeRoleFromProfileCredentialsProvider" + System.currentTimeMillis();
 		AWSCredentialsProvider profileCredentials = new ProfileCredentialsProvider();
-		AWSSecurityTokenServiceClientBuilder builder = AWSSecurityTokenServiceClientBuilder.standard().withCredentials(profileCredentials);
+		AWSSecurityTokenServiceClientBuilder builder = AWSSecurityTokenServiceClientBuilder.standard().
+				withCredentials(profileCredentials).
+				withRegion(region);
 		AWSSecurityTokenService service = builder.build();
 		provider = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn,  sessionName).withStsClient(service).build();
 	}


### PR DESCRIPTION
When I tried to use the jar in intellij, I got an error that a region must be set, I overloaded the constructor to allow a region to be passed as an optional value, and set the default as the AWS default region, "us-east-1".

I also added some more specific installation instructions for configuring the driver in IntelliJ.